### PR TITLE
Remove use of directory IDs

### DIFF
--- a/client/save.go
+++ b/client/save.go
@@ -55,7 +55,7 @@ func (c *Client) getRelationTypes(ctx context.Context, data Manifest, object *v2
 
 	for {
 		relReq := &reader.GetRelationTypesRequest{
-			Param: &v2.ObjectTypeIdentifier{Id: &object.Id},
+			Param: &v2.ObjectTypeIdentifier{Name: &object.Name},
 			Page:  &v2.PaginationRequest{Token: token},
 		}
 		resp, err := c.Reader.GetRelationTypes(ctx, relReq)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aserto-dev/clui v0.8.1
-	github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad
+	github.com/aserto-dev/go-directory v0.20.6
 	github.com/magefile/mage v1.14.0
 	github.com/mattn/go-isatty v0.0.16
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aserto-dev/clui v0.8.1
-	github.com/aserto-dev/go-directory v0.20.4
+	github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad
 	github.com/magefile/mage v1.14.0
 	github.com/mattn/go-isatty v0.0.16
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/aserto-dev/clui v0.8.1 h1:5IW9OnFZoIWjvnmTE4FNTXrjP1wnMzd39qKAcRnRHt8=
 github.com/aserto-dev/clui v0.8.1/go.mod h1:XpJxwNzSQaGN6rqXONZJEaeez4MUaCPikM2lKSngrXM=
-github.com/aserto-dev/go-directory v0.20.4 h1:vZlgrirt9o/9p20aJSuQ7DZgKWiAJku2Aqy3p0XF6Ho=
-github.com/aserto-dev/go-directory v0.20.4/go.mod h1:gjg6wZezLGXJj1LBEXaJUS9kpOnaDWeFUYhDG1TAkTY=
+github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad h1:Ay40WBmZW8AR3U1JVj6un4szszu3XIxgwhH5Ew6OYkE=
+github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad/go.mod h1:gjg6wZezLGXJj1LBEXaJUS9kpOnaDWeFUYhDG1TAkTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/aserto-dev/clui v0.8.1 h1:5IW9OnFZoIWjvnmTE4FNTXrjP1wnMzd39qKAcRnRHt8=
 github.com/aserto-dev/clui v0.8.1/go.mod h1:XpJxwNzSQaGN6rqXONZJEaeez4MUaCPikM2lKSngrXM=
-github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad h1:Ay40WBmZW8AR3U1JVj6un4szszu3XIxgwhH5Ew6OYkE=
-github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad/go.mod h1:gjg6wZezLGXJj1LBEXaJUS9kpOnaDWeFUYhDG1TAkTY=
+github.com/aserto-dev/go-directory v0.20.6 h1:D8ttv2YfYUBFr+stxZ6ZXGaycw66MGb0Ooj2Lk7RH+0=
+github.com/aserto-dev/go-directory v0.20.6/go.mod h1:gjg6wZezLGXJj1LBEXaJUS9kpOnaDWeFUYhDG1TAkTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,5 +1,5 @@
-github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad h1:Ay40WBmZW8AR3U1JVj6un4szszu3XIxgwhH5Ew6OYkE=
-github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad/go.mod h1:gjg6wZezLGXJj1LBEXaJUS9kpOnaDWeFUYhDG1TAkTY=
+github.com/aserto-dev/go-directory v0.20.6 h1:D8ttv2YfYUBFr+stxZ6ZXGaycw66MGb0Ooj2Lk7RH+0=
+github.com/aserto-dev/go-directory v0.20.6/go.mod h1:gjg6wZezLGXJj1LBEXaJUS9kpOnaDWeFUYhDG1TAkTY=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,4 +1,5 @@
-github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
+github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad h1:Ay40WBmZW8AR3U1JVj6un4szszu3XIxgwhH5Ew6OYkE=
+github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad/go.mod h1:gjg6wZezLGXJj1LBEXaJUS9kpOnaDWeFUYhDG1TAkTY=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=


### PR DESCRIPTION
This PR removes the use of object-type IDs in preparation for the next version of the pb-directory which no longer exposes IDs.